### PR TITLE
Initialize README and basic docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# AdaptiveMindscape
+
+AdaptiveMindscape is a full-stack TypeScript application that demonstrates a real-time AI reflection engine.
+It combines a Node/Express backend, a Postgres database via Drizzle ORM, and a React frontend served with Vite.
+
+## Repository Structure
+
+- **client/** – React frontend built with Vite and Tailwind CSS
+- **server/** – Express API, WebSocket server, and simplified neural engine
+- **shared/** – Database schema and shared TypeScript types
+- **attached_assets/** – Miscellaneous assets from development
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Configure environment variables:
+   - `DATABASE_URL` – connection string for Postgres (Neon is used by default)
+   - `OPENAI_API_KEY` – key for OpenAI API calls
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   This will run the Express API and the Vite dev server on port `5000`.
+
+## Scripts
+
+- `npm run dev` – start the server in development with hot reload
+- `npm run build` – build the client and server for production
+- `npm run start` – run the production build
+- `npm run check` – type check the project with TypeScript
+
+## Features
+
+- WebSocket updates for live reflection and generation events
+- Custom neural engine with tokenization and training placeholders
+- Drizzle ORM models defined in `shared/schema.ts`
+- React UI with reusable components from Radix and Tailwind
+
+For more details see the documentation in the `docs/` directory.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,28 @@
+# Architecture Overview
+
+AdaptiveMindscape consists of a Node/Express backend and a React frontend. Both share TypeScript types defined under `shared/`.
+
+## Backend
+
+- Located in `server/`.
+- `index.ts` sets up middleware and registers API and WebSocket routes.
+- `routes.ts` defines REST endpoints under `/api` and broadcasts events over WebSockets.
+- `neural-engine.ts` implements a small transformer-like model used for generation demos.
+- `storage.ts` provides a `DatabaseStorage` class that wraps Drizzle ORM queries.
+
+## Frontend
+
+- Located in `client/` with Vite configuration.
+- `src/pages/adaptive-ai.tsx` is the main page that connects to the server using React Query and a custom WebSocket hook.
+- UI components are in `src/components/` and styled with Tailwind CSS.
+
+## Database Schema
+
+Drizzle ORM tables are defined in `shared/schema.ts`. They include `sessions`, `reflections`, `memory_insights`, and tables for storing neural network weights and vocabulary.
+
+## Development Workflow
+
+1. Run `npm run dev` to start the server with Vite in development mode.
+2. Navigate to `http://localhost:5000` to access the frontend UI.
+3. WebSocket messages stream reflections and generation updates in real time.
+


### PR DESCRIPTION
## Summary
- add a project README with setup instructions and feature overview
- document high level architecture in `docs/architecture.md`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684a34b023a883298da773158ee1e977