### PR TITLE
Fix learning progress display

### DIFF
--- a/client/src/components/performance-metrics.tsx
+++ b/client/src/components/performance-metrics.tsx
@@ -29,7 +29,7 @@ export function PerformanceMetrics({ data }: PerformanceMetricsProps) {
             <span className="text-sm font-medium text-slate-300">Learning Progress</span>
             <span className="text-sm font-mono text-blue-400">+{data.learningProgress}%</span>
           </div>
-          <Progress value={76} className="h-2" />
+          <Progress value={data.learningProgress} className="h-2" />
         </CardContent>
       </Card>
       


### PR DESCRIPTION
## Summary
- show real learning progress in `PerformanceMetrics`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a37df43dc8329a52de456f697a9d4